### PR TITLE
Finish registeredPOMmea table functionality

### DIFF
--- a/app/Http/Controllers/PrintLabel/PrintLabelMmeaController.php
+++ b/app/Http/Controllers/PrintLabel/PrintLabelMmeaController.php
@@ -10,9 +10,11 @@ use Inertia\Inertia;
 
 class PrintLabelMmeaController extends Controller
 {
-    public function index()
+    public function index($no_po = null)
     {
-        return Inertia::render('PrintLabel/PrintLabelMmea/Index');
+        return Inertia::render('PrintLabel/PrintLabelMmea/Index', [
+            'no_po' => $no_po,
+        ]);
     }
 
     public function store(Request $request)

--- a/resources/js/Pages/PrintLabel/PrintLabelMmea/Index.vue
+++ b/resources/js/Pages/PrintLabel/PrintLabelMmea/Index.vue
@@ -5,7 +5,7 @@
  * TODO : Get Array From No Rim
  *
  */
-import { ref, inject, computed, watch } from 'vue';
+import { ref, inject, computed, watch, onMounted } from 'vue';
 import { Head, useForm } from '@inertiajs/vue3';
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout.vue";
 import TextInput from "@/Components/TextInput.vue";
@@ -35,6 +35,14 @@ const PRINT_TIMEOUT_BASE = 1000;
 const DEBOUNCE_DELAY = 500;
 const VALIDATION_DELAY = 300;
 const printFrame = ref(null);
+// Props
+const props = defineProps({
+    no_po: {
+        type: [String, Number],
+        default: null
+    }
+});
+
 // Injections
 const swal = inject('$swal');
 
@@ -48,7 +56,7 @@ const printTimeout = computed(() =>
 );
 
 const isLoading = ref(false);
-const nomorPo = ref(0);
+const nomorPo = ref(props.no_po || 0);
 const printMode = ref("both");
 const rowCount = ref(1);
 
@@ -465,6 +473,22 @@ const handleNpInput = () => {
     clearTimeout(npDebounceTimer);
     errors.value.labelQuantity = '';
 };
+
+// Auto-initialize when component receives no_po prop
+onMounted(() => {
+    if (props.no_po) {
+        nomorPo.value = props.no_po;
+        InitDataLabel();
+    }
+});
+
+// Watch for changes in no_po prop (in case of navigation updates)
+watch(() => props.no_po, (newValue) => {
+    if (newValue && newValue !== nomorPo.value) {
+        nomorPo.value = newValue;
+        InitDataLabel();
+    }
+});
 </script>
 
 <template>

--- a/resources/js/Pages/RegisteredPo/RegisteredPoMmea/Edit.vue
+++ b/resources/js/Pages/RegisteredPo/RegisteredPoMmea/Edit.vue
@@ -1,0 +1,216 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import { Link, useForm } from '@inertiajs/vue3';
+import { FileText, Layers, Hash, Save, ArrowLeft, AlertCircle } from 'lucide-vue-next';
+import { inject, ref } from 'vue';
+
+const swal = inject("$swal");
+
+const props = defineProps({
+    data_product: Object,
+    data_periksa: Array,
+});
+
+const form = useForm({
+    no_obc: props.data_product?.no_obc || '',
+    type: props.data_product?.type || 'MMEA',
+    labels: props.data_periksa?.map(label => ({
+        nomor_rim: label.nomor_rim,
+        periksa1: label.periksa1 || '',
+        periksa2: label.periksa2 || '',
+        lbr_kemas: label.lbr_kemas || '',
+    })) || [],
+});
+
+const submit = () => {
+    form.put(route('dataPoMmea.update', { no_po: props.data_product.no_po }), {
+        onSuccess: () => {
+            swal.fire({
+                icon: "success",
+                title: "Berhasil",
+                text: "Data PO berhasil diperbarui",
+                showConfirmButton: false,
+                timer: 1500
+            });
+        },
+        onError: (errors) => {
+            swal.fire({
+                icon: "error",
+                title: "Gagal",
+                text: "Terjadi kesalahan saat memperbarui data",
+                confirmButtonText: 'OK'
+            });
+        },
+    });
+};
+</script>
+
+<template>
+    <AuthenticatedLayout>
+        <div class="min-h-screen py-12">
+            <div class="container mx-auto px-4 max-w-7xl">
+                <!-- Header Section -->
+                <div
+                    class="bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-2xl shadow-lg p-8 mb-8 border border-slate-100 dark:border-slate-700">
+                    <div class="mb-6">
+                        <h1 class="text-4xl font-bold text-slate-900 dark:text-white text-center tracking-tight">
+                            Edit Data Produksi PC Berperekat
+                        </h1>
+                        <p class="text-center text-slate-500 dark:text-slate-400 mt-2">
+                            Nomor PO: {{ props.data_product?.no_po }}
+                        </p>
+                    </div>
+
+                    <!-- Main Info Form -->
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <!-- OBC -->
+                        <div class="bg-slate-50/50 dark:bg-slate-700/50 rounded-xl p-6">
+                            <div class="flex items-center justify-center gap-3 mb-3">
+                                <Layers class="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
+                                <InputLabel for="obc" value="Nomor OBC"
+                                    class="text-lg font-semibold text-slate-700 dark:text-slate-300" />
+                            </div>
+                            <TextInput 
+                                id="obc" 
+                                v-model="form.no_obc"
+                                type="text"
+                                class="text-xl text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-xl shadow-sm dark:text-white"
+                                :class="{ 'border-red-500': form.errors.no_obc }"
+                                autocomplete="obc" />
+                            <div v-if="form.errors.no_obc" class="mt-2 text-sm text-red-600 dark:text-red-400">
+                                {{ form.errors.no_obc }}
+                            </div>
+                        </div>
+
+                        <!-- Produk Type -->
+                        <div class="bg-slate-50/50 dark:bg-slate-700/50 rounded-xl p-6">
+                            <div class="flex items-center justify-center gap-3 mb-3">
+                                <Hash class="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+                                <InputLabel for="type" value="Produk"
+                                    class="text-lg font-semibold text-slate-700 dark:text-slate-300" />
+                            </div>
+                            <select 
+                                id="type" 
+                                v-model="form.type"
+                                class="w-full text-xl text-center bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-xl shadow-sm dark:text-white px-4 py-3 transition-all duration-200"
+                                :class="{ 'border-red-500': form.errors.type }">
+                                <option value="MMEA">MMEA</option>
+                                <option value="HPTL">HPTL</option>
+                            </select>
+                            <div v-if="form.errors.type" class="mt-2 text-sm text-red-600 dark:text-red-400">
+                                {{ form.errors.type }}
+                            </div>
+                        </div>
+
+                        <!-- PO (Read-only) -->
+                        <div class="bg-slate-50/50 dark:bg-slate-700/50 rounded-xl p-6">
+                            <div class="flex items-center justify-center gap-3 mb-3">
+                                <FileText class="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                                <InputLabel for="po" value="Nomor PO"
+                                    class="text-lg font-semibold text-slate-700 dark:text-slate-300" />
+                            </div>
+                            <TextInput 
+                                id="po" 
+                                :value="props.data_product?.no_po" 
+                                type="text"
+                                class="text-xl text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-xl shadow-sm dark:text-white"
+                                disabled />
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Labels Edit Section -->
+                <div
+                    class="bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-2xl shadow-lg p-8 border border-slate-100 dark:border-slate-700">
+                    <div class="mb-6">
+                        <h2 class="text-2xl font-bold text-slate-900 dark:text-white mb-2">
+                            Edit Data Label
+                        </h2>
+                        <p class="text-slate-500 dark:text-slate-400">
+                            Edit data periksa dan lebar kemas untuk setiap rim
+                        </p>
+                    </div>
+
+                    <!-- Labels Table -->
+                    <div class="overflow-x-auto">
+                        <table class="w-full">
+                            <thead class="bg-slate-50 dark:bg-slate-700/50">
+                                <tr>
+                                    <th class="px-4 py-3 text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase text-center whitespace-nowrap">
+                                        Nomor Rim
+                                    </th>
+                                    <th class="px-4 py-3 text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase text-center whitespace-nowrap">
+                                        Periksa 1
+                                    </th>
+                                    <th class="px-4 py-3 text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase text-center whitespace-nowrap">
+                                        Periksa 2
+                                    </th>
+                                    <th class="px-4 py-3 text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase text-center whitespace-nowrap">
+                                        Lebar Kemas
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+                                <tr v-for="(label, index) in form.labels" :key="label.nomor_rim"
+                                    class="hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors duration-150">
+                                    <td class="px-4 py-3 text-sm text-center font-medium text-slate-900 dark:text-white">
+                                        {{ label.nomor_rim }}
+                                    </td>
+                                    <td class="px-4 py-3">
+                                        <TextInput 
+                                            v-model="form.labels[index].periksa1"
+                                            type="text"
+                                            class="text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-lg dark:text-white"
+                                            placeholder="-" />
+                                    </td>
+                                    <td class="px-4 py-3">
+                                        <TextInput 
+                                            v-model="form.labels[index].periksa2"
+                                            type="text"
+                                            class="text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-lg dark:text-white"
+                                            placeholder="-" />
+                                    </td>
+                                    <td class="px-4 py-3">
+                                        <TextInput 
+                                            v-model="form.labels[index].lbr_kemas"
+                                            type="text"
+                                            class="text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-lg dark:text-white"
+                                            placeholder="-" />
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div v-if="form.errors.labels" class="mt-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                        <div class="flex items-center gap-2">
+                            <AlertCircle class="w-5 h-5 text-red-600 dark:text-red-400" />
+                            <p class="text-sm text-red-600 dark:text-red-400">{{ form.errors.labels }}</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Action Buttons -->
+                <div class="flex flex-col sm:flex-row justify-between gap-4 mt-8">
+                    <Link 
+                        :href="route('dataPoMmea.index')"
+                        class="inline-flex items-center justify-center gap-2 px-6 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-700 transition-all duration-200">
+                        <ArrowLeft class="w-5 h-5" />
+                        Kembali
+                    </Link>
+                    <PrimaryButton 
+                        @click="submit"
+                        :disabled="form.processing"
+                        class="inline-flex items-center justify-center gap-2 px-6 py-3 text-sm font-medium">
+                        <Save class="w-5 h-5" />
+                        <span v-if="form.processing">Menyimpan...</span>
+                        <span v-else>Simpan Perubahan</span>
+                    </PrimaryButton>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/RegisteredPo/RegisteredPoMmea/Edit.vue
+++ b/resources/js/Pages/RegisteredPo/RegisteredPoMmea/Edit.vue
@@ -2,7 +2,6 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import TextInput from '@/Components/TextInput.vue';
-import PrimaryButton from '@/Components/PrimaryButton.vue';
 import { Link, useForm } from '@inertiajs/vue3';
 import { FileText, Layers, Hash, Save, ArrowLeft, AlertCircle } from 'lucide-vue-next';
 import { inject, ref } from 'vue';
@@ -65,7 +64,7 @@ const submit = () => {
                     </div>
 
                     <!-- Main Info Form -->
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
                         <!-- OBC -->
                         <div class="bg-slate-50/50 dark:bg-slate-700/50 rounded-xl p-6">
                             <div class="flex items-center justify-center gap-3 mb-3">
@@ -77,7 +76,7 @@ const submit = () => {
                                 id="obc" 
                                 v-model="form.no_obc"
                                 type="text"
-                                class="text-xl text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-xl shadow-sm dark:text-white"
+                                class="text-xl text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-xl shadow-sm dark:text-white focus:border-blue-500 focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-900"
                                 :class="{ 'border-red-500': form.errors.no_obc }"
                                 autocomplete="obc" />
                             <div v-if="form.errors.no_obc" class="mt-2 text-sm text-red-600 dark:text-red-400">
@@ -95,7 +94,7 @@ const submit = () => {
                             <select 
                                 id="type" 
                                 v-model="form.type"
-                                class="w-full text-xl text-center bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-xl shadow-sm dark:text-white px-4 py-3 transition-all duration-200"
+                                class="w-full text-xl text-center bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-xl shadow-sm dark:text-white px-4 py-3 transition-all duration-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-900 focus:outline-none"
                                 :class="{ 'border-red-500': form.errors.type }">
                                 <option value="MMEA">MMEA</option>
                                 <option value="HPTL">HPTL</option>
@@ -124,7 +123,7 @@ const submit = () => {
 
                 <!-- Labels Edit Section -->
                 <div
-                    class="bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-2xl shadow-lg p-8 border border-slate-100 dark:border-slate-700">
+                    class="bg-white/90 dark:bg-slate-800/90 backdrop-blur-xl rounded-2xl shadow-lg p-8 mb-8 border border-slate-100 dark:border-slate-700">
                     <div class="mb-6">
                         <h2 class="text-2xl font-bold text-slate-900 dark:text-white mb-2">
                             Edit Data Label
@@ -135,8 +134,9 @@ const submit = () => {
                     </div>
 
                     <!-- Labels Table -->
-                    <div class="overflow-x-auto">
-                        <table class="w-full">
+                    <div class="overflow-hidden bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700">
+                        <div class="overflow-x-auto">
+                            <table class="w-full">
                             <thead class="bg-slate-50 dark:bg-slate-700/50">
                                 <tr>
                                     <th class="px-4 py-3 text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase text-center whitespace-nowrap">
@@ -163,26 +163,27 @@ const submit = () => {
                                         <TextInput 
                                             v-model="form.labels[index].periksa1"
                                             type="text"
-                                            class="text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-lg dark:text-white"
+                                            class="w-full text-sm text-center bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg dark:text-white focus:border-blue-500 focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-900 transition-all duration-200"
                                             placeholder="-" />
                                     </td>
                                     <td class="px-4 py-3">
                                         <TextInput 
                                             v-model="form.labels[index].periksa2"
                                             type="text"
-                                            class="text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-lg dark:text-white"
+                                            class="w-full text-sm text-center bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg dark:text-white focus:border-blue-500 focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-900 transition-all duration-200"
                                             placeholder="-" />
                                     </td>
                                     <td class="px-4 py-3">
                                         <TextInput 
                                             v-model="form.labels[index].lbr_kemas"
                                             type="text"
-                                            class="text-center bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600 rounded-lg dark:text-white"
+                                            class="w-full text-sm text-center bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg dark:text-white focus:border-blue-500 focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-900 transition-all duration-200"
                                             placeholder="-" />
                                     </td>
                                 </tr>
                             </tbody>
                         </table>
+                        </div>
                     </div>
 
                     <div v-if="form.errors.labels" class="mt-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
@@ -197,18 +198,18 @@ const submit = () => {
                 <div class="flex flex-col sm:flex-row justify-between gap-4 mt-8">
                     <Link 
                         :href="route('dataPoMmea.index')"
-                        class="inline-flex items-center justify-center gap-2 px-6 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-700 transition-all duration-200">
+                        class="inline-flex items-center justify-center gap-2 px-6 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-700 transition-all duration-200 shadow-sm hover:shadow">
                         <ArrowLeft class="w-5 h-5" />
                         Kembali
                     </Link>
-                    <PrimaryButton 
+                    <button
                         @click="submit"
                         :disabled="form.processing"
-                        class="inline-flex items-center justify-center gap-2 px-6 py-3 text-sm font-medium">
+                        class="inline-flex items-center justify-center gap-2 px-6 py-3 text-sm font-medium text-white bg-blue-600 dark:bg-blue-500 rounded-xl hover:bg-blue-700 dark:hover:bg-blue-600 transition-all duration-200 shadow-lg hover:shadow-xl hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0">
                         <Save class="w-5 h-5" />
                         <span v-if="form.processing">Menyimpan...</span>
                         <span v-else>Simpan Perubahan</span>
-                    </PrimaryButton>
+                    </button>
                 </div>
             </div>
         </div>

--- a/resources/js/Pages/RegisteredPo/RegisteredPoMmea/Index.vue
+++ b/resources/js/Pages/RegisteredPo/RegisteredPoMmea/Index.vue
@@ -6,6 +6,7 @@ import Modal from '@/Components/Modal.vue';
 import { Link, router, useForm } from '@inertiajs/vue3';
 import { Home, Search, Trash2, Eye, Edit, Printer } from 'lucide-vue-next';
 import { inject, ref } from 'vue';
+import axios from 'axios';
 
 const swal = inject("$swal")
 

--- a/resources/js/Pages/RegisteredPo/RegisteredPoMmea/Show.vue
+++ b/resources/js/Pages/RegisteredPo/RegisteredPoMmea/Show.vue
@@ -202,7 +202,7 @@ const openModalDetailProduksi = (dataLabel) => {
                                             <span class="text-sm font-bold text-emerald-700 dark:text-emerald-400">{{
                                                 periksa.periksa1 }}</span>
                                             <span class="text-sm font-medium text-indigo-600 dark:text-indigo-400">{{
-                                                periksa.no_rim }}</span>
+                                                periksa.nomor_rim }}</span>
                                         </div>
                                     </button>
 
@@ -216,7 +216,7 @@ const openModalDetailProduksi = (dataLabel) => {
                                             <span class="text-sm font-bold text-amber-700 dark:text-amber-400">{{
                                                 periksa.periksa1 }}</span>
                                             <span class="text-sm font-medium text-indigo-600 dark:text-indigo-400">{{
-                                                periksa.no_rim }}</span>
+                                                periksa.nomor_rim }}</span>
                                         </div>
                                     </button>
 
@@ -226,7 +226,7 @@ const openModalDetailProduksi = (dataLabel) => {
                                         <div class="flex flex-col items-center gap-1">
                                             <span class="text-sm font-bold text-slate-400 dark:text-slate-500">-</span>
                                             <span class="text-sm font-medium text-indigo-600 dark:text-indigo-400">{{
-                                                periksa.no_rim }}</span>
+                                                periksa.nomor_rim }}</span>
                                         </div>
                                     </button>
                                 </template>
@@ -276,7 +276,7 @@ const openModalDetailProduksi = (dataLabel) => {
                                             <span class="text-sm font-bold text-emerald-700 dark:text-emerald-400">{{
                                                 periksa.periksa2 }}</span>
                                             <span class="text-sm font-medium text-indigo-600 dark:text-indigo-400">{{
-                                                periksa.no_rim }}</span>
+                                                periksa.nomor_rim }}</span>
                                         </div>
                                     </button>
 
@@ -290,7 +290,7 @@ const openModalDetailProduksi = (dataLabel) => {
                                             <span class="text-sm font-bold text-amber-700 dark:text-amber-400">{{
                                                 periksa.periksa2 }}</span>
                                             <span class="text-sm font-medium text-indigo-600 dark:text-indigo-400">{{
-                                                periksa.no_rim }}</span>
+                                                periksa.nomor_rim }}</span>
                                         </div>
                                     </button>
 
@@ -300,7 +300,7 @@ const openModalDetailProduksi = (dataLabel) => {
                                         <div class="flex flex-col items-center gap-1">
                                             <span class="text-sm font-bold text-slate-400 dark:text-slate-500">-</span>
                                             <span class="text-sm font-medium text-indigo-600 dark:text-indigo-400">{{
-                                                periksa.no_rim }}</span>
+                                                periksa.nomor_rim }}</span>
                                         </div>
                                     </button>
                                 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,7 +79,7 @@ Route::middleware('auth')->group(function () {
 
     // Print Label Routes
     Route::get('/print-label/inspeksi', [App\Http\Controllers\PrintLabel\PrintLabelInspeksiController::class, 'index'])->name('printLabel.inspeksi');
-    Route::get('/print-label/mmea', [App\Http\Controllers\PrintLabel\PrintLabelMmeaController::class, 'index'])->name('printLabel.mmea');
+    Route::get('/print-label/mmea/{no_po?}', [App\Http\Controllers\PrintLabel\PrintLabelMmeaController::class, 'index'])->name('printLabel.mmea');
 });
 
 // Include authentication routes


### PR DESCRIPTION
Implement edit functionality for the registeredPOMmea table and fix a field name inconsistency in the show view.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e187047-9905-433e-810d-b3a4f573fe51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7e187047-9905-433e-810d-b3a4f573fe51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an edit page for Registered PO MMEA, fixes rim field name usage, and enables deep-linking/auto-init of Print Label MMEA via optional `no_po` route param.
> 
> - **Frontend**:
>   - **Registered PO MMEA**:
>     - New `resources/js/Pages/RegisteredPo/RegisteredPoMmea/Edit.vue` to edit product (`no_obc`, `type`) and label data; submits via `PUT dataPoMmea.update`.
>     - `Index.vue`: adds Print action linking to `route('printLabel.mmea', { no_po })`; uses `axios` for search.
>     - `Show.vue`: replace `periksa.no_rim` with `periksa.nomor_rim` in status cards.
>   - **Print Label MMEA**:
>     - `PrintLabel/PrintLabelMmea/Index.vue`: accepts `no_po` prop, initializes `nomorPo` from it, and auto-loads data on mount/watch.
> - **Backend/Routes**:
>   - `PrintLabelMmeaController@index` accepts optional `$no_po` and passes it to Inertia.
>   - Route `GET /print-label/mmea/{no_po?}` updated to accept an optional `no_po` parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d51003b973c8eeec6d3a56a0be067593438ffcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->