### PR TITLE
Refactor order and print label services

### DIFF
--- a/app/Http/Controllers/OrderBesar/CetakLabelController.php
+++ b/app/Http/Controllers/OrderBesar/CetakLabelController.php
@@ -40,7 +40,7 @@ class CetakLabelController extends Controller
     public function index(string $team, string $id)
     {
         $product = GeneratedProducts::findOrFail($id);
-        $noRimData = $this->fetchNoRim($product->no_po);
+        $noRimData = $this->printLabelService->fetchNextRim($product->no_po);
 
         return Inertia::render('OrderBesar/CetakLabel/Index', [
             'product' => $product,
@@ -134,7 +134,7 @@ class CetakLabelController extends Controller
     {
         try {
             $product = GeneratedProducts::findOrFail($id);
-            $noRimData = $this->fetchNoRim($product->no_po);
+            $noRimData = $this->printLabelService->fetchNextRim($product->no_po);
 
             return response()->json([
                 'product' => $product,
@@ -149,68 +149,6 @@ class CetakLabelController extends Controller
         } catch (\Exception $e) {
             return response()->json(['error' => 'Failed to fetch data'], 500);
         }
-    }
-
-    private function fetchNoRim(string $po): array
-    {
-        $baseQuery = $this->getBaseQuery($po);
-
-        $inschietResult = $this->checkInschietRims($baseQuery);
-        if ($inschietResult) return $inschietResult;
-
-        $nextKiri = $this->getNextRim($baseQuery, self::POTONGAN_KIRI);
-        $nextKanan = $this->getNextRim($baseQuery, self::POTONGAN_KANAN);
-
-        return $this->determineNextRim($nextKiri, $nextKanan);
-    }
-
-    private function getBaseQuery(string $po)
-    {
-        return GeneratedLabels::where('no_po_generated_products', $po)
-            ->where(fn($query) => $query->whereNull('np_users')->orWhere('np_users', ''))
-            ->orderBy('no_rim');
-    }
-
-    private function checkInschietRims($baseQuery): ?array
-    {
-        foreach ([self::POTONGAN_KIRI, self::POTONGAN_KANAN] as $potongan) {
-            $inschiet = (clone $baseQuery)
-                ->where('potongan', $potongan)
-                ->where('no_rim', self::INSCHIET_RIM)
-                ->whereNull('start')
-                ->first();
-
-            if ($inschiet) {
-                return ['noRim' => self::INSCHIET_RIM, 'potongan' => $potongan];
-            }
-        }
-        return null;
-    }
-
-    private function getNextRim($baseQuery, string $potongan)
-    {
-        return (clone $baseQuery)
-            ->where('potongan', $potongan)
-            ->first();
-    }
-
-    private function determineNextRim($nextKiri, $nextKanan): array
-    {
-        if (!$nextKiri && !$nextKanan) {
-            return ['noRim' => 0, 'potongan' => 'Finished'];
-        }
-
-        if (!$nextKiri) {
-            return ['noRim' => $nextKanan->no_rim, 'potongan' => self::POTONGAN_KANAN];
-        }
-
-        if (!$nextKanan) {
-            return ['noRim' => $nextKiri->no_rim, 'potongan' => self::POTONGAN_KIRI];
-        }
-
-        return $nextKiri->no_rim <= $nextKanan->no_rim
-            ? ['noRim' => $nextKiri->no_rim, 'potongan' => self::POTONGAN_KIRI]
-            : ['noRim' => $nextKanan->no_rim, 'potongan' => self::POTONGAN_KANAN];
     }
 
     private function updateGeneratedLabel(Request $request, string $npPetugas): void

--- a/app/Http/Controllers/OrderKecil/CetakLabelController.php
+++ b/app/Http/Controllers/OrderKecil/CetakLabelController.php
@@ -64,12 +64,4 @@ class CetakLabelController extends Controller
             ], 422);
         }
     }
-
-    private function countNullNp(string $noPo): int
-    {
-        return GeneratedLabels::query()
-            ->where('no_po_generated_products', $noPo)
-            ->whereNull('np_users')
-            ->count();
-    }
 }

--- a/app/Http/Controllers/PrintLabel/PrintLabelInspeksiController.php
+++ b/app/Http/Controllers/PrintLabel/PrintLabelInspeksiController.php
@@ -49,12 +49,8 @@ class PrintLabelInspeksiController extends Controller
     {
         $isPoRegistered = GeneratedProducts::where('no_po', $no_po)->first();
 
-        $countLabel = GeneratedLabels::where('no_po_generated_products', $no_po)
-                             ->whereNull('np_users')
-                             ->count();
-
         if ($isPoRegistered) {
-            return $countLabel;
+            return $this->printLabelService->getRemainingLabelCount($no_po);
         } else {
             $specification = Specification::where('no_po', $no_po)->first();
 
@@ -158,7 +154,7 @@ class PrintLabelInspeksiController extends Controller
         $failedLabels = 0;
 
         for ($i = 0; $i < $validatedData['jumlah_label']; $i++) {
-            $label = $this->getNextAvailableLabel($validatedData['no_po']);
+            $label = $this->printLabelService->getNextAvailableLabel($validatedData['no_po'], 'desc');
 
             if (!$label) {
                 // Only log this if we couldn't process any labels - indicates a real issue
@@ -168,7 +164,12 @@ class PrintLabelInspeksiController extends Controller
                 break;
             }
 
-            if ($this->updateLabel($label, $validatedData)) {
+            if ($this->printLabelService->updateLabelWithInspection(
+                $label,
+                $validatedData['np1'],
+                $validatedData['np2'] ?? null,
+                $validatedData['team']
+            )) {
                 $processedLabels++;
             } else {
                 $failedLabels++;
@@ -182,39 +183,6 @@ class PrintLabelInspeksiController extends Controller
             'failed_labels' => $failedLabels,
             'remaining_labels' => $remainingLabels
         ];
-    }
-
-    private function getNextAvailableLabel(int $no_po)
-    {
-        return GeneratedLabels::where('no_po_generated_products', $no_po)
-                             ->whereNull('np_users')
-                             ->orderBy('no_rim', 'desc')
-                             ->first();
-    }
-
-    private function updateLabel($label, array $validatedData): bool
-    {
-        try {
-            $label->update([
-                'np_users' => strtoupper($validatedData['np1']),
-                'np_user_p2' => strtoupper($validatedData['np2']),
-                'workstation' => $validatedData['team'],
-                'start' => now(),
-                'finish' => now(),
-            ]);
-
-            return true;
-
-        } catch (\Exception $e) {
-            // Only log errors - successful updates don't need logging
-            Log::error('Failed to update label', [
-                'label_id' => $label->id,
-                'no_po' => $validatedData['no_po'] ?? 'unknown',
-                'error' => $e->getMessage()
-            ]);
-
-            return false;
-        }
     }
 
     private function updateProductionOrderStatus(int $no_po, int $remainingLabels): void

--- a/app/Http/Controllers/PrintLabel/PrintLabelMmeaController.php
+++ b/app/Http/Controllers/PrintLabel/PrintLabelMmeaController.php
@@ -5,11 +5,18 @@ namespace App\Http\Controllers\PrintLabel;
 use App\Http\Controllers\Controller;
 use App\Models\GeneratedLabelsMmea;
 use App\Models\GeneratedProducts;
+use App\Services\PrintLabelService;
+use App\Services\ProductionOrderService;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
 class PrintLabelMmeaController extends Controller
 {
+    public function __construct(
+        protected PrintLabelService $printLabelService,
+        protected ProductionOrderService $productionOrderService
+    ) {}
+
     public function index($no_po = null)
     {
         return Inertia::render('PrintLabel/PrintLabelMmea/Index', [
@@ -20,7 +27,7 @@ class PrintLabelMmeaController extends Controller
     public function store(Request $request)
     {
         foreach($request->no_rim as $nomor_rim) {
-            // Check Existiing Data
+            // Check Existing Data
             $current_data = GeneratedLabelsMmea::where('nomor_po', $request->no_po)
                                 ->where('nomor_rim',$nomor_rim)
                                 ->first();
@@ -28,8 +35,12 @@ class PrintLabelMmeaController extends Controller
             $key_kemas = "no_".$nomor_rim;
             $key_pemeriksa = "np_".$nomor_rim;
 
-            $periksa1   = $this->convNp($request->periksa1[$key_pemeriksa] ?? $request->periksa1['np_1']);
-            $periksa2   = $this->convNp($request->periksa2[$key_pemeriksa] ?? $request->periksa2['np_1']);
+            $periksa1 = $this->printLabelService->convertNpFormat(
+                $request->periksa1[$key_pemeriksa] ?? $request->periksa1['np_1']
+            );
+            $periksa2 = $this->printLabelService->convertNpFormat(
+                $request->periksa2[$key_pemeriksa] ?? $request->periksa2['np_1']
+            );
 
             if($current_data !==  null) {
                 $waktu_p1 = $current_data->periksa1 == strtoupper($periksa1) ? $current_data->waktu_p1 : now();
@@ -38,7 +49,6 @@ class PrintLabelMmeaController extends Controller
                 $waktu_p1 = now();
                 $waktu_p2 = now();
             }
-
 
             GeneratedLabelsMmea::updateOrCreate(
                 [
@@ -58,33 +68,17 @@ class PrintLabelMmeaController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Label berhasil diproses',
-            // 'data' => [
-            //     'processed_labels' => $result['processed_labels'],
-            //     'failed_labels' => $result['failed_labels'],
-            //     'remaining_labels' => $result['remaining_labels'],
-            //     'status' => $result['remaining_labels'] > 0 ? 'in_progress' : 'completed'
-            // ]
         ]);
     }
 
     public function storeProduct(Request $request)
     {
-        $sum_rim = round($request->jml_lbr,0,PHP_ROUND_HALF_UP);
-
-        GeneratedProducts::updateOrCreate(
-            [
-                'no_po' => $request->no_po,
-            ],
-            [
-                'no_obc'  => $request->no_obc,
-                'type'    => $request->produk,
-                'sum_rim' => $sum_rim,
-                'start_rim' => 1,
-                'end_rim'   => $sum_rim,
-                'assigned_team' => 6, //MMEA
-                'status'    => 2
-            ]
-        );
+        $this->productionOrderService->registerOrUpdateMmeaProduct([
+            'no_po' => $request->no_po,
+            'no_obc' => $request->no_obc,
+            'produk' => $request->produk,
+            'jml_lbr' => $request->jml_lbr
+        ]);
     }
 
     public function qcData(int $nomor_po)
@@ -93,16 +87,4 @@ class PrintLabelMmeaController extends Controller
                     ->orderBy('nomor_rim')
                     ->get();
     }
-
-    private function convNp($np)
-    {
-        if(strlen($np) > 4) {
-            $firstLetter = substr($np, 0, 1);
-            $lastFour = substr($np, (strlen($np) - 4), strlen($np));
-            $np = $firstLetter . $lastFour;
-        }
-
-        return $np;
-    }
-
 }

--- a/app/Services/PrintLabelService.php
+++ b/app/Services/PrintLabelService.php
@@ -227,8 +227,114 @@ class PrintLabelService
         );
     }
 
-    private function formatPeriksaName(?string $name): ?string
+    public function getRemainingLabelCount(int $noPo): int
+    {
+        return GeneratedLabels::where('no_po_generated_products', $noPo)
+            ->whereNull('np_users')
+            ->count();
+    }
+
+    public function getNextAvailableLabel(int $noPo, string $orderBy = 'asc')
+    {
+        return GeneratedLabels::where('no_po_generated_products', $noPo)
+            ->whereNull('np_users')
+            ->orderBy('no_rim', $orderBy)
+            ->first();
+    }
+
+    public function updateLabelWithInspection(
+        $label,
+        string $np1,
+        ?string $np2,
+        int $team
+    ): bool {
+        try {
+            $label->update([
+                'np_users' => strtoupper($np1),
+                'np_user_p2' => $np2 ? strtoupper($np2) : null,
+                'workstation' => $team,
+                'start' => now(),
+                'finish' => now(),
+            ]);
+
+            return true;
+        } catch (\Exception $e) {
+            \Log::error('Failed to update label', [
+                'label_id' => $label->id,
+                'error' => $e->getMessage()
+            ]);
+
+            return false;
+        }
+    }
+
+    public function fetchNextRim(string $po): array
+    {
+        $baseQuery = GeneratedLabels::where('no_po_generated_products', $po)
+            ->where(fn($query) => $query->whereNull('np_users')->orWhere('np_users', ''))
+            ->orderBy('no_rim');
+
+        // Check for inschiet rims first
+        $inschietResult = $this->checkInschietRims($baseQuery);
+        if ($inschietResult) {
+            return $inschietResult;
+        }
+
+        // Get next available rim for both Kiri and Kanan
+        $nextKiri = (clone $baseQuery)->where('potongan', 'Kiri')->first();
+        $nextKanan = (clone $baseQuery)->where('potongan', 'Kanan')->first();
+
+        return $this->determineNextRim($nextKiri, $nextKanan);
+    }
+
+    public function formatPeriksaName(?string $name): ?string
     {
         return $name ? strtoupper($name) : null;
+    }
+
+    public function convertNpFormat(string $np): string
+    {
+        if (strlen($np) > 4) {
+            $firstLetter = substr($np, 0, 1);
+            $lastFour = substr($np, (strlen($np) - 4), strlen($np));
+            return $firstLetter . $lastFour;
+        }
+
+        return $np;
+    }
+
+    private function checkInschietRims($baseQuery): ?array
+    {
+        foreach (['Kiri', 'Kanan'] as $potongan) {
+            $inschiet = (clone $baseQuery)
+                ->where('potongan', $potongan)
+                ->where('no_rim', self::INSCHIET_RIM_NUMBER)
+                ->whereNull('start')
+                ->first();
+
+            if ($inschiet) {
+                return ['noRim' => self::INSCHIET_RIM_NUMBER, 'potongan' => $potongan];
+            }
+        }
+        return null;
+    }
+
+    private function determineNextRim($nextKiri, $nextKanan): array
+    {
+        if (!$nextKiri && !$nextKanan) {
+            return ['noRim' => 0, 'potongan' => 'Finished'];
+        }
+
+        if (!$nextKiri) {
+            return ['noRim' => $nextKanan->no_rim, 'potongan' => 'Kanan'];
+        }
+
+        if (!$nextKanan) {
+            return ['noRim' => $nextKiri->no_rim, 'potongan' => 'Kiri'];
+        }
+
+        return $nextKiri->no_rim <= $nextKanan->no_rim
+            ? ['noRim' => $nextKiri->no_rim, 'potongan' => 'Kiri']
+            : ['noRim' => $nextKanan->no_rim, 'potongan' => 'Kanan'];
     }
 }

--- a/app/Services/ProductionOrderService.php
+++ b/app/Services/ProductionOrderService.php
@@ -63,6 +63,24 @@ class ProductionOrderService
             ->count() === 0;
     }
 
+    public function registerOrUpdateMmeaProduct(array $productData): void
+    {
+        $sumRim = round($productData['jml_lbr'], 0, PHP_ROUND_HALF_UP);
+
+        GeneratedProducts::updateOrCreate(
+            ['no_po' => $productData['no_po']],
+            [
+                'no_obc'  => $productData['no_obc'],
+                'type'    => $productData['produk'] ?? 'MMEA',
+                'sum_rim' => $sumRim,
+                'start_rim' => 1,
+                'end_rim'   => $sumRim,
+                'assigned_team' => 6, // MMEA team
+                'status'    => 2
+            ]
+        );
+    }
+
     private function calculateTotalRims(int $totalSheets): int
     {
         return max(floor($totalSheets / self::SHEETS_PER_RIM), self::MIN_RIM);


### PR DESCRIPTION
Refactor label and production order controllers to remove redundant code and delegate business logic to dedicated services.

This PR centralizes label fetching, updating, and production order registration logic into `PrintLabelService` and `ProductionOrderService`, cleaning up `OrderBesar/CetakLabelController`, `OrderKecil/CetakLabelController`, `PrintLabelInspeksiController`, and `PrintLabelMmeaController`. The goal is to improve separation of concerns, enhance code reusability, and simplify maintenance.

---
<a href="https://cursor.com/background-agent?bcId=bc-0daa0ddf-36c6-443a-bc29-3d71e8e0a37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0daa0ddf-36c6-443a-bc29-3d71e8e0a37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

